### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/Senpai-Sama7/Acropolis/security/code-scanning/8](https://github.com/Senpai-Sama7/Acropolis/security/code-scanning/8)

To fix the problem, add an explicit `permissions` block to the `build` job in the workflow file. Since the `build` job only needs to check out code and run local build commands, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the job to read repository contents. This should be added directly under the `build` job definition (i.e., after `runs-on: ubuntu-latest`). No other changes are needed, and this will not affect the existing functionality of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
