### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Senpai-Sama7/Acropolis/security/code-scanning/7](https://github.com/Senpai-Sama7/Acropolis/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. Since the workflow only checks out code and runs build/test commands, it does not require any write permissions. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow (before `jobs:`), which will apply to all jobs unless overridden. This change should be made in `.github/workflows/rust.yml` above the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
