### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -170,6 +170,8 @@ jobs:
         sarif_file: 'trivy-results.sarif'
 
   security-report:
+    permissions:
+      issues: write
     name: Security Report
     runs-on: ubuntu-latest
     needs: [security-audit, dependency-review, secret-scanning, container-security]


### PR DESCRIPTION
Potential fix for [https://github.com/Senpai-Sama7/Acropolis/security/code-scanning/5](https://github.com/Senpai-Sama7/Acropolis/security/code-scanning/5)

To fix the problem, add a `permissions` block to the `security-report` job in `.github/workflows/security.yml`. This block should grant only the permissions required for the job to function. Since the job creates a GitHub issue using the REST API, it only needs `issues: write` permission. No other permissions are required. The `permissions` block should be added directly under the `security-report:` job definition (after line 172 and before `name:` on line 173) to scope it to this job only, leaving other jobs unaffected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
