### PR TITLE
Streamline imports for PPTX image conversion

### DIFF
--- a/models/python/pptx_to_img.py
+++ b/models/python/pptx_to_img.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from typing import Any, Sequence, cast, List, Dict
+from typing import Any, cast, Dict, List, Sequence
 
 import numpy as np
 from pdf2image import convert_from_path

--- a/models/python/pptx_to_img.py
+++ b/models/python/pptx_to_img.py
@@ -3,9 +3,10 @@
 
 import argparse
 import os
+import shutil
 import subprocess
 import tempfile
-from typing import Any, Sequence, cast, List, Tuple, Dict
+from typing import Any, Sequence, cast, List, Dict
 
 import numpy as np
 from pdf2image import convert_from_path
@@ -244,7 +245,6 @@ def main() -> None:
         )
     else:
         # Clean up temp directory if there are no failures
-        import shutil
         shutil.rmtree(overflow_results["temp_directory"])
 
     # Final rasterization of the original presentation


### PR DESCRIPTION
### **User description**
## Summary
- centralize imports and remove unused typing in `pptx_to_img.py`
- use top-level `shutil` import for temp directory cleanup

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile models/python/pptx_to_img.py models/python/create_montage.py`


------
https://chatgpt.com/codex/tasks/task_b_68c6e31aaba883309562f8ac61821e7f


___

### **PR Type**
Other


___

### **Description**
- Move `shutil` import to top-level imports

- Remove unused `Tuple` type import

- Streamline import organization for better code structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Import reorganization"] --> B["Move shutil to top"]
  A --> C["Remove unused Tuple"]
  B --> D["Cleaner code structure"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pptx_to_img.py</strong><dd><code>Reorganize imports and remove unused types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

models/python/pptx_to_img.py

<ul><li>Move <code>shutil</code> import from local scope to top-level imports<br> <li> Remove unused <code>Tuple</code> type from typing imports<br> <li> Improve code organization and import structure</ul>


</details>


  </td>
  <td><a href="https://github.com/Senpai-Sama7/Acropolis/pull/61/files#diff-16f279f3dfee0eeb81a3802648b60999b021d2c21bca4cc88653235484e84dd8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

